### PR TITLE
surfaceflinger: Pass proper transform orientation to setProjection()

### DIFF
--- a/services/surfaceflinger/DisplayDevice.cpp
+++ b/services/surfaceflinger/DisplayDevice.cpp
@@ -272,13 +272,17 @@ void DisplayDevice::setProjection(int orientation,
         scissor = displayBounds;
     }
 
+    uint32_t transformOrientation;
+
     if (isPrimary()) {
         sPrimaryDisplayOrientation = displayStateOrientationToTransformOrientation(orientation);
+        transformOrientation = displayStateOrientationToTransformOrientation(
+                (orientation + mDisplayInstallOrientation) % (DisplayState::eOrientation270 + 1));
+    } else {
+        transformOrientation = displayStateOrientationToTransformOrientation(orientation);
     }
 
-    getCompositionDisplay()->setProjection(globalTransform,
-                                           displayStateOrientationToTransformOrientation(
-                                                   orientation),
+    getCompositionDisplay()->setProjection(globalTransform, transformOrientation,
                                            frame, viewport, scissor, needsFiltering);
 }
 


### PR DESCRIPTION
* Without adding display install orientation,
  the orientation passed to setProjection()
  is incorrect thus screen contents aren't
  rendered properly.

Change-Id: Ieba6992bd6148c0480a2cae681c85bed75de30f1